### PR TITLE
Feat: Zustand와 localStorage를 사용하여 설문조사 데이터 유지 기능 구현

### DIFF
--- a/src/components/reservation/ReservationForm.tsx
+++ b/src/components/reservation/ReservationForm.tsx
@@ -1,6 +1,6 @@
 import { useSurveyResultsStore } from '@/store/Store';
 import { treatmentPrices } from '../recFlow/TreatmentPrices';
-
+import { useEffect } from 'react';
 interface FormFieldProps {
   label: string;
   ans: string;
@@ -36,8 +36,13 @@ interface ReservationFormProps {
 }
 
 const ReservationForm = ({ selectedDate }: ReservationFormProps) => {
-  const { recommendedMethod, similarTreatments, price } =
+  const { recommendedMethod, similarTreatments, price, loadFromLocal } =
     useSurveyResultsStore();
+
+  // 페이지 로드 시 localStorage에서 값 불러오기
+  useEffect(() => {
+    loadFromLocal();
+  }, [loadFromLocal]);
 
   // 비용 계산 로직
   const calculatePriceDetails = (methods: string) => {

--- a/src/store/Store.tsx
+++ b/src/store/Store.tsx
@@ -33,6 +33,7 @@ interface SurveyResultsState {
   recommendedMethod: string | undefined;
   similarTreatments: string | undefined;
   setSurveyResults: (answers: string[]) => void;
+  loadFromLocal: () => void; // localStorage에서 값 로드
 }
 export const useSurveyResultsStore = create<SurveyResultsState>()(
   devtools(
@@ -44,6 +45,7 @@ export const useSurveyResultsStore = create<SurveyResultsState>()(
       price: undefined,
       recommendedMethod: undefined,
       similarTreatments: undefined,
+
       setSurveyResults: (answers) => {
         const treatmentPurpose = answers[0] || '기본값'; // 기본값 설정
         const treatmentMethod =
@@ -97,6 +99,24 @@ export const useSurveyResultsStore = create<SurveyResultsState>()(
         localStorage.setItem('SurveyResults', JSON.stringify(surveyResults)); // 결과를 로컬 스토리지에 저장
         console.log('설문 결과 저장:', surveyResults);
       },
+
+      // 로컬스토리지에서 값 로드
+      loadFromLocal: () => {
+        const storedResults = localStorage.getItem('SurveyResults');
+        if (storedResults) {
+          const parsedResults = JSON.parse(storedResults);
+          set({
+            treatmentPurpose: parsedResults.treatmentPurpose,
+            treatmentMethod: parsedResults.treatmentMethod,
+            recommendedMethod: parsedResults.recommendedMethod,
+            similarTreatments: parsedResults.similarTreatments,
+            injectionArea: parsedResults.injectionArea,
+            sideEffects: parsedResults.sideEffects,
+            price: parsedResults.price,
+          });
+        }
+      },
+
       clearSurveyResults: () =>
         set({
           treatmentPurpose: undefined,


### PR DESCRIPTION
- localStorage에 설문조사 데이터를 저장하고, 로그인 후 페이지 이동 시 데이터를 유지하도록 수정
- ReservationForm 페이지에서 useEffect를 사용해 localStorage에서 데이터를 불러와 Zustand 스토어에 저장하는 로직 추가
- 설문조사 결과와 추천 시술, 유사 시술 정보를 지속적으로 유지하고 불러오는 기능 구현
- 로그인 후 상태가 초기화되지 않도록 데이터 복원 처리